### PR TITLE
updated link to biostars/aspera setup tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ kingfisher -h
 ```
 
 Optionally, to use the `ena-ascp` method, an Aspera connect client is also required.
-See https://www.ibm.com/aspera/connect/ or [https://www.biostars.org/p/325010/](https://www.biostars.org/p/9528910/)
+See https://www.ibm.com/aspera/connect/ or [https://www.biostars.org/p/9528910/](https://www.biostars.org/p/9528910/)
 
 @MakeTheBrainHappy implemented an example installation (and usage) guide in [Google Colaboratory](https://colab.research.google.com/drive/1k3RC-WbVAAl6h8yXtfEhwqCAvCMHspzz?usp=sharing) and [Jupyter Notebook](https://github.com/MakeTheBrainHappy/kingfisher-cloud).
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ kingfisher -h
 ```
 
 Optionally, to use the `ena-ascp` method, an Aspera connect client is also required.
-See https://www.ibm.com/aspera/connect/ or https://www.biostars.org/p/325010/
+See https://www.ibm.com/aspera/connect/ or [https://www.biostars.org/p/325010/](https://www.biostars.org/p/9528910/)
 
 @MakeTheBrainHappy implemented an example installation (and usage) guide in [Google Colaboratory](https://colab.research.google.com/drive/1k3RC-WbVAAl6h8yXtfEhwqCAvCMHspzz?usp=sharing) and [Jupyter Notebook](https://github.com/MakeTheBrainHappy/kingfisher-cloud).
 


### PR DESCRIPTION
Hi, just updated the link to biostars for the tutorial on how to setup Aspera because the old one is now deprecated.