### PR TITLE
limiting the maximum number of download threads

### DIFF
--- a/kingfisher/ena.py
+++ b/kingfisher/ena.py
@@ -124,6 +124,9 @@ class EnaDownloader:
                 logging.info("Downloading {} ..".format(url))
                 output_file = os.path.basename(url)
                 if num_threads > 1:
+                    if num_threads > 16:
+                        logging.warn("Limited the number of download threads to 16, the max for aria2c")
+                        num_threads = 16
                     cmd = "aria2c -x{} -o {} 'ftp://{}'".format(
                         num_threads, output_file, url)
                 else:


### PR DESCRIPTION
If you provide aria2c with more than 16 threads it dies rather rudely. 

Here is an example, requesting 64 download threads:

```
04/14/2025 03:13:19 PM INFO: Kingfisher v0.4.1
04/14/2025 03:13:34 PM INFO: Attempting download method ena-ftp for run SRR8482173 ..
04/14/2025 03:13:34 PM INFO: Querying ENA for FTP paths for SRR8482173..
04/14/2025 03:13:36 PM INFO: Downloading ftp.sra.ebi.ac.uk/vol1/fastq/SRR848/003/SRR8482173/SRR8482173.fastq.gz ..
Exception: [AbstractOptionHandler.cc:69] errorCode=28 We encountered a problem while processing the option '--max-connection-per-server'.
  -> [OptionHandlerImpl.cc:184] errorCode=1 max-connection-per-server must be between 1 and 16.
Usage:
 -x, --max-connection-per-server=NUM The maximum number of connections to one
                              server for each download.

                              Possible Values: 1-16
                              Default: 1
                              Tags: #basic, #http, #ftp
04/14/2025 03:13:37 PM WARNING: Method ena-ftp failed, error was Command 'aria2c -x64 -o SRR8482173.fastq.gz 'ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR848/003/SRR8482173/SRR8482173.fastq.gz'' returned non-zero exit status 28.
04/14/2025 03:13:37 PM WARNING: Method ena-ftp failed
Traceback (most recent call last):
  File "/kingfisher/bin/kingfisher", line 323, in <module>
    main()
  File "/kingfisher/bin/kingfisher", line 266, in main
    kingfisher.download_and_extract(
  File "/kingfisher/bin/../kingfisher/__init__.py", line 72, in download_and_extract
    download_and_extract_one_run(run, **kwargs)
  File "/kingfisher/bin/../kingfisher/__init__.py", line 365, in download_and_extract_one_run
    raise Exception("No more specified download methods, cannot continue")
Exception: No more specified download methods, cannot continue
```

If `num_threads` is above 16, this PR just sets `num_threads` to 16 and provides a warning.