### PR TITLE
Handle malformed ENA file-report responses gracefully

### DIFF
--- a/kingfisher/ena.py
+++ b/kingfisher/ena.py
@@ -30,7 +30,18 @@ class EnaDownloader:
         header = True
         logging.debug("Found text from ENA API: {}".format(text))
 
-        df = pd.read_csv(StringIO(text), sep='\t', header=0, index_col=False)
+        try:
+            df = pd.read_csv(StringIO(text), sep='\t', header=0, index_col=False)
+        except (pd.errors.ParserError, pd.errors.EmptyDataError) as e:
+            logging.error("Unexpected ENA API response for accession {}: {}".format(run_id, e))
+            return False
+
+        required_columns = ['fastq_ftp', 'fastq_md5']
+        if any(column not in df.columns for column in required_columns):
+            logging.error(
+                "Unexpected ENA API response for accession {}: missing one or more required columns ({})".format(
+                    run_id, ', '.join(required_columns)))
+            return False
 
         # Expect just 1 row
         if len(df) == 0:
@@ -45,8 +56,11 @@ class EnaDownloader:
 
         for _, row in df.iterrows():
             # e.g. ERR1346134 at time of writing. See https://github.com/wwood/kingfisher-download/issues/25
-            if isinstance(float("nan"), type(row['fastq_ftp'])):
+            if pd.isna(row['fastq_ftp']) or row['fastq_ftp'] == '':
                 logging.error("No ENA FTP download URLs found for run {}, cannot continue".format(run_id))
+                return False
+            if pd.isna(row['fastq_md5']) or row['fastq_md5'] == '':
+                logging.error("No ENA FTP MD5 checksums found for run {}, cannot continue".format(run_id))
                 return False
             ftp_urls = row['fastq_ftp'].split(';')
             md5sums = row['fastq_md5'].split(';')
@@ -144,4 +158,3 @@ class EnaDownloader:
                         return False
                 downloaded.append(os.path.join(output_directory, output_file))
         return downloaded
-

--- a/test/test_ena_unit.py
+++ b/test/test_ena_unit.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+
+import os.path
+import sys
+import unittest
+
+sys.path = [os.path.join(os.path.dirname(os.path.realpath(__file__)),'..')] + sys.path
+
+import kingfisher.ena
+
+
+class Tests(unittest.TestCase):
+    def test_get_ftp_download_urls_handles_unexpected_response(self):
+        original_run = kingfisher.ena.extern.run
+        try:
+            kingfisher.ena.extern.run = lambda _: "accession\nERR123\n"
+            result = kingfisher.ena.EnaDownloader().get_ftp_download_urls("ERR123")
+            self.assertFalse(result)
+        finally:
+            kingfisher.ena.extern.run = original_run
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- ENA file-report API responses can be malformed, empty, or missing expected columns which used to raise uncaught exceptions during parsing and break download flows.

### Description
- Guard `EnaDownloader.get_ftp_download_urls` by catching `pandas` parse errors (`pd.errors.ParserError` and `pd.errors.EmptyDataError`) and returning `False` with a clear log message instead of raising.
- Validate that the required columns `fastq_ftp` and `fastq_md5` exist in the parsed DataFrame and return `False` with a log message if they are missing.
- Tighten missing-data checks for `fastq_ftp` and `fastq_md5` using `pd.isna(...)` and empty-string checks so invalid records fail cleanly.
- Add a focused unit test `test/test_ena_unit.py` that stubs the ENA API response via `kingfisher.ena.extern.run` to simulate an unexpected response and asserts that `get_ftp_download_urls` returns `False`.

### Testing
- Added and committed the unit test file `test/test_ena_unit.py` which exercises the malformed-response handling by stubbing `kingfisher.ena.extern.run` and expecting `False` as the result. 
- Ran `python test/test_ena_unit.py` inside the container which failed with `ModuleNotFoundError: No module named 'extern'` due to missing runtime/test dependency in this environment. 
- Running `python -m unittest test/test_ena_unit.py` also failed to import the test module in this container for the same missing-dependency/path reasons.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d049d57e80832abd1b9e58f6d927b4)